### PR TITLE
Include LICENSE and version.inc in the distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,5 +3,5 @@
 
 SUBDIRS = src
 
-EXTRA_DIST = autogen.sh
+EXTRA_DIST = autogen.sh LICENSE
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,7 @@ sleefits.f \
 systemfunction.f \
 truebeg.f \
 truelen.f \
+version.inc \
 writefits.f \
 zscale.f
 


### PR DESCRIPTION
I have updated `Makefile.am` and `src/Makefile.am` to include `LICENSE` and `version.inc` in the distribution tarball.